### PR TITLE
add codeql

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,26 @@
+# name: "Security and Quality"
+
+# queries: 
+#   - name: Security and Quality
+#     uses: security-and-quality
+
+name: "My CodeQL config"
+
+disable-default-queries: false
+
+#paths:
+#  - src
+paths-ignore:
+  - restaurant/lib
+  #- src/node_modules
+  #- '**/*.test.js'
+
+#queries:
+  # - name: Custom
+  #   uses: ./.github/workflows/codeql/queries/Log4JndiInjection.ql
+  # - name: Extended Security
+  #   uses: security-extended
+  # - name: Security and Quality
+  #   uses: security-and-quality
+  # - name: codeql repo
+  #   uses: github/codeql/java/ql/src/codeql-suites/java-code-scanning.qls@v1.24.0

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -11,7 +11,8 @@ disable-default-queries: false
 #paths:
 #  - src
 paths-ignore:
-  - restaurant/lib
+  - restaurant/lib  
+  - restaurant/lib/python3.6/site-packages/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
   #- src/node_modules
   #- '**/*.test.js'
 

--- a/.github/codeql/codeql-lib-config.yml
+++ b/.github/codeql/codeql-lib-config.yml
@@ -1,0 +1,10 @@
+name: "My CodeQL config"
+
+disable-default-queries: false
+
+paths:
+#  - src
+  - restaurant/lib
+paths-ignore:  
+  #- src/node_modules
+  #- '**/*.test.js'

--- a/.github/codeql/codeql-lib-config.yml
+++ b/.github/codeql/codeql-lib-config.yml
@@ -8,3 +8,5 @@ disable-default-queries: false
 #paths-ignore:  
   #- src/node_modules
   #- '**/*.test.js'
+paths-ignore:
+  - restaurant/lib/python3.6/site-packages/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js

--- a/.github/codeql/codeql-lib-config.yml
+++ b/.github/codeql/codeql-lib-config.yml
@@ -2,9 +2,9 @@ name: "My CodeQL config"
 
 disable-default-queries: false
 
-paths:
+#paths:
 #  - src
-  - restaurant/lib
+#  - restaurant/lib
 #paths-ignore:  
   #- src/node_modules
   #- '**/*.test.js'

--- a/.github/codeql/codeql-lib-config.yml
+++ b/.github/codeql/codeql-lib-config.yml
@@ -5,6 +5,6 @@ disable-default-queries: false
 paths:
 #  - src
   - restaurant/lib
-paths-ignore:  
+#paths-ignore:  
   #- src/node_modules
   #- '**/*.test.js'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,11 +46,12 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
+        config-file: ./.github/codeql/codeql-config.yml
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        # queries: security-extended,security-and-quality        
 
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,72 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '24 8 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,8 +17,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
-  schedule:
-    - cron: '24 8 * * 5'
+  #schedule:
+  #  - cron: '24 8 * * 5'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-lib-analysis.yml
+++ b/.github/workflows/codeql-lib-analysis.yml
@@ -12,11 +12,12 @@
 name: "CodeQL Lib"
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
+  workflow_dispatch:
+  #push:
+  #  branches: [ master ]
+  #pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+  #  branches: [ master ]
   #schedule:
   #  - cron: '24 8 * * 5'
 

--- a/.github/workflows/codeql-lib-analysis.yml
+++ b/.github/workflows/codeql-lib-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: "CodeQL Lib"
 
 on:
   push:

--- a/.github/workflows/codeql-lib-analysis.yml
+++ b/.github/workflows/codeql-lib-analysis.yml
@@ -1,0 +1,73 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  #schedule:
+  #  - cron: '24 8 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        config-file: ./.github/codeql/codeql-lib-config.yml
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality        
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Must use config file to exclude paths in codeql scans
- [Use a config File and exclude paths not needed (ex: Django pip installed site-modules source )]( https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#specifying-directories-to-scan
)
```
		paths-ignore:
		  - restaurant/lib
		  - src/node_modules
		  - '**/*.test.js'

```

Codeql by default seems to exclude library findings
UNLESS you explicitly configure Paths to INCLUDE libs - this added 44 findings in lib folder ... only a handful of them marked as Library, Generated OR Library + Generated :\ [You have no control over these labels - they are determined by path](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-alerts#about-labels-for-alerts-that-are-not-found-in-application-code)

```
paths:
  - restaurant/lib
```

![image](https://user-images.githubusercontent.com/1760475/170724390-15273ec6-1609-4ee3-bc14-2974113d58c2.png)
